### PR TITLE
add parse_head => 0 option to ua

### DIFF
--- a/lib/WWW/YouTube/Download.pm
+++ b/lib/WWW/YouTube/Download.pm
@@ -22,6 +22,7 @@ sub new {
     my %args = @_;
     $args{ua} = LWP::UserAgent->new(
         agent => __PACKAGE__.'/'.$VERSION,
+        parse_head => 0,
     ) unless exists $args{ua};
     bless \%args, $class;
 }


### PR DESCRIPTION
Hello!

It seems that youtube-download script fails
with a message "failed to extract JSON data".

The reason of failure is that youtube page contains

```
<meta name="twitter:card" ...>
```

and HTTP::Headers module croaks "Illegal field name" there.

Perhaps WWW::YouTube::Download module do not need to parse headers,
I added parse_head => 0 option to LWP::UserAgent.

Thank you.
