### PR TITLE
PRC: CPANTS error missing_prereqs

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -16,7 +16,9 @@ use File::Spec;
 my %args = (
     license              => 'perl',
     dynamic_config       => 0,
-
+	requires => {
+		'HTTP::Request'	=> 6.11,
+	},
     configure_requires => {
         'Module::Build' => 0.38,
     },


### PR DESCRIPTION
CPANTS error missing_prereqs fixed: added dependency on HTTP::Request
6.11