### PR TITLE
Changed the hashes for the videos in youtube.t. The existing

### DIFF
--- a/t/youtube.t
+++ b/t/youtube.t
@@ -29,10 +29,10 @@ sub check_video_fetch_url {
     is $code, 200;
 }
 
-# random free video
-check_video_fetch_url('Kdgt1ZHkvnM');
+# YAPC video 1	
+check_video_fetch_url('Y1I1KcKvz9Q');
 
-# vevo
-check_video_fetch_url('cmSbXsFE3l8');
+# YAPC video 2 
+check_video_fetch_url('oAkasBMJJ18');
 
 done_testing;


### PR DESCRIPTION
hashes pointed to videos that had been removed from youtube
and were resulting in 403 errors.

I also noticed that the hashes needed to be added from videos
as they show for a user not logged into google.