### PR TITLE
fix regexp warning with perl 5.28

### DIFF
--- a/lib/WWW/YouTube/Download.pm
+++ b/lib/WWW/YouTube/Download.pm
@@ -227,7 +227,7 @@ sub _get_args {
         if ($line =~ /the uploader has not made this video available in your country/i) {
             croak 'Video not available in your country';
         }
-        elsif ($line =~ /^.+ytplayer\.config\s*=\s*({.*})/) {
+        elsif ($line =~ /^.+ytplayer\.config\s*=\s*(\{.*})/) {
             ($data, undef) = JSON->new->utf8(1)->decode_prefix($1);
             last;
         }


### PR DESCRIPTION

In Debian we are currently applying the following patch to
WWW-YouTube-Download.
We thought you might be interested in it too.

    Description: fix regexp warning with perl 5.28:
     Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/^.+ytplayer\.config\s*=\s*({ <-- HERE .*})/ at /build/libwww-youtube-download-perl-0.59/blib/lib/WWW/YouTube/Download.pm line 230.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/903497
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-07-10
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libwww-youtube-download-perl/raw/master/debian/patches/unescaped_left_brace-perl5.28.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
