### PR TITLE
Fix extracting the video title from a playlist

### DIFF
--- a/lib/WWW/YouTube/Download.pm
+++ b/lib/WWW/YouTube/Download.pm
@@ -547,13 +547,14 @@ sub _find_playlist_videos {
     for my $renderer ( @{ $playlistVideoListRenderer->{contents} } ) {
         $cnt++;
         my $video = $renderer->{playlistVideoRenderer};
+        my $titleText = @$video->{title}->{runs} ? $video->{title}->{runs}->[0]->{text} : $video->{title}->{simpleText};
 
         push(
             @videos,
             {
                 id      => $video->{videoId},
                 runtime => $video->{lengthSeconds},
-                title   => ( $video->{title}->{simpleText} || 'undef' )
+                title   => ( $titleText || 'undef' )
                 ,    # encoded in Perl internal
             }
         );
@@ -562,7 +563,7 @@ sub _find_playlist_videos {
             print " $cnt id:" . $video->{videoId};
             print " runtime:" . ( $video->{lengthSeconds} || 'undef' );
             print " title:"
-                . Encode::encode_utf8( $video->{title}->{simpleText}
+                . Encode::encode_utf8( $titleText
                     || 'undef' );
             print "\n";
         }
@@ -644,13 +645,14 @@ sub _find_playlist_json_videos {
     for my $renderer ( @{ $playlistVideoListContinuation->{contents} } ) {
         $cnt++;
         my $video = $renderer->{playlistVideoRenderer};
+        my $titleText = @$video->{title}->{runs} ? $video->{title}->{runs}->[0]->{text} : $video->{title}->{simpleText};
 
         push(
             @videos,
             {
                 id      => $video->{videoId},
                 runtime => $video->{lengthSeconds},
-                title   => ( $video->{title}->{simpleText} || 'undef' )
+                title   => ( $titleText || 'undef' )
                 ,    # encoded in Perl internal
             }
         );
@@ -659,7 +661,7 @@ sub _find_playlist_json_videos {
             print " $cnt id:" . $video->{videoId};
             print " runtime:" . ( $video->{lengthSeconds} || 'undef' );
             print " title:"
-                . Encode::encode_utf8( $video->{title}->{simpleText}
+                . Encode::encode_utf8( $titleText
                     || 'undef' );
             print "\n";
         }

--- a/lib/WWW/YouTube/Download.pm
+++ b/lib/WWW/YouTube/Download.pm
@@ -547,7 +547,7 @@ sub _find_playlist_videos {
     for my $renderer ( @{ $playlistVideoListRenderer->{contents} } ) {
         $cnt++;
         my $video = $renderer->{playlistVideoRenderer};
-        my $titleText = @$video->{title}->{runs} ? $video->{title}->{runs}->[0]->{text} : $video->{title}->{simpleText};
+        my $titleText = @{$video->{title}->{runs}} ? $video->{title}->{runs}->[0]->{text} : $video->{title}->{simpleText};
 
         push(
             @videos,
@@ -645,7 +645,7 @@ sub _find_playlist_json_videos {
     for my $renderer ( @{ $playlistVideoListContinuation->{contents} } ) {
         $cnt++;
         my $video = $renderer->{playlistVideoRenderer};
-        my $titleText = @$video->{title}->{runs} ? $video->{title}->{runs}->[0]->{text} : $video->{title}->{simpleText};
+        my $titleText = @{$video->{title}->{runs}} ? $video->{title}->{runs}->[0]->{text} : $video->{title}->{simpleText};
 
         push(
             @videos,


### PR DESCRIPTION
See https://github.com/xaicron/p5-www-youtube-download/issues/63

I don't know exactly what `$video->{title}->{simpleText}` is so I have left that in as a fallback. However when I stepped through this problem in the debugger, I only saw the following keys on `$video->{title}` : `accessibility` and `runs`. The latter was an array containing a single hash reference which contained the text key.

Tested on a few different playlists which all consistently follow this pattern.

See here for the debug info, stepping in after line 549 with a test playlist:
```
DB<14> x keys %$video
0  'title'
1  'menu'
2  'isPlayable'
3  'thumbnail'
4  'index'
5  'videoId'
6  'trackingParams'
7  'lengthSeconds'
8  'navigationEndpoint'
9  'shortBylineText'
10  'thumbnailOverlays'
11  'lengthText'
  DB<15> x keys %{$video->{title}}
0  'accessibility'
1  'runs'
  DB<16> x $video->{title}
0  HASH(0x55f9e726fa58)
   'accessibility' => HASH(0x55f9e6d16cf0)
      'accessibilityData' => HASH(0x55f9e6d16738)
         'label' => 'Among Us but there is an idiot among us by Call Me Kevin 2 months ago 15 minutes'
   'runs' => ARRAY(0x55f9e6d16b40)
      0  HASH(0x55f9e6d16cc0)
         'text' => 'Among Us but there is an idiot among us'
```